### PR TITLE
Fix the bulk case & make api semantics more like the local api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+
+node_js:
+ - "0.10"
+
+install:
+ - npm install
+
+before_script:
+ - npm install npm
+
+script:
+ - npm test

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 var request = require('request')
 var qs = require('querystring')
 var btoa = require('btoa')
-
+var debug = require('debug')('dat-api-client')
 module.exports = DatAPI
 
 function DatAPI (opts, cb) {
   if (!(this instanceof DatAPI)) return new DatAPI(opts, cb)
-  this.remote = opts.remote
+  this.url = opts.url
   this.auth = 'Basic ' + btoa(opts.user + ':' + opts.pass)
 }
 
@@ -14,16 +14,21 @@ DatAPI.prototype.info = function (cb) {
   return this._req('', 'GET', null, {}, cb)
 }
 
-DatAPI.prototype.row = function (key, opts, cb) {
+DatAPI.prototype.get = function (key, cb) {
+  if (typeof key === 'function') {
+    cb = key
+    opts = {}
+    return this._req('rows', 'GET', null, opts, cb)
+  }
+
   return this._req('rows/' + key, 'GET', null, opts, cb)
 }
 
-DatAPI.prototype.rows =
-DatAPI.prototype.getRows = function (opts, cb) {
-  return this._req('rows', 'GET', null, opts, cb)
-}
-
-DatAPI.prototype.postRows = function (data, opts, cb) {
+DatAPI.prototype.put = function (data, opts, cb) {
+  if (opts == 'function') {
+    opts = {type: 'json'}
+    cb = opts
+  }
   return this._req('rows', 'POST', data, opts, cb)
 }
 
@@ -38,7 +43,7 @@ DatAPI.prototype.postBlob = function (blob, opts, cb) {
   return this._req(uri, 'POST', blob, opts, cb)
 }
 
-DatAPI.prototype.diff = 
+DatAPI.prototype.diff =
 DatAPI.prototype.changes = function (opts, cb) {
   return this._req('changes', 'GET', null, opts, cb)
 }
@@ -88,19 +93,34 @@ DatAPI.prototype._req = function (resource, method, data, opts, cb) {
   if (opts.tail) query.tail = opts.tail
   if (opts.live) query.live = opts.live
 
-  opts.uri = this.remote + '/api/' + resource + '?' + qs.stringify(query)
+  opts.uri = this.url + '/api/' + resource + '?' + qs.stringify(query)
   opts.method = method
   opts.headers = {}
-  
+
   if (opts.type) {
     if (opts.type == 'csv') opts.headers['content-type'] = 'text/csv'
     if (opts.type == 'json') opts.headers['content-type'] = 'application/json'
   }
   else opts.json = true
-  
-  if (data) opts.json = data
-  if (this.auth) opts.headers.authorization = this.auth
 
-  if (!cb) return request(opts)
-  else request(opts, cb)
+  if (this.auth) opts.headers.authorization = this.auth
+  if (data && opts.type != 'csv') opts.json = data
+
+  debug('request', opts)
+
+  var req = request(opts, cb)
+
+  if (opts.type == 'csv' && data) {
+    debug('writing', data)
+    req.write(data)
+    req.on('response', function (resp) {
+      return cb(null, resp, true)
+    })
+    req.on('error', function (err) {
+      return cb(err)
+    })
+    req.end()
+  }
+
+  return req
 }

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ DatAPI.prototype.get = function (key, cb) {
 
 DatAPI.prototype.put = function (data, opts, cb) {
   if (opts == 'function') {
-    opts = {type: 'json'}
+    opts = { type: 'json' } // json by default
     cb = opts
   }
   return this._req('rows', 'POST', data, opts, cb)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dat-api-client",
   "description": "A wrapper for the dat rest API.",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "repository": {
     "url": "git://github.com/sethvincent/dat-api-client.git"
   },
@@ -18,6 +18,7 @@
     "xhr": "^1.17.0"
   },
   "devDependencies": {
+    "debug": "^2.1.0",
     "tape": "^3.0.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,10 @@
 # dat-api-client
 
-A wrapper for the dat rest API.
+A JavaScript wrapper for dat's [REST API](https://github.com/maxogden/dat/blob/master/docs/rest-api.md).
+
+[![NPM](https://nodei.co/npm/dat-api-client.png?global=true)](https://nodei.co/npm/dat-api-client/)
+
+[![Travis](http://img.shields.io/travis/sethvincent/dat-api-client.svg?style=flat)](https://travis-ci.org/sethvincent/dat-api-client)
 
 ## Install
 
@@ -13,7 +17,7 @@ npm i --save dat-api-client
 ```
 var datAPI = require('dat-api-client')
 
-var dat = datAPI({ 
+var dat = datAPI({
   remote: 'http://127.0.0.1:6461',
   user: 'foo',
   pass: 'bar'

--- a/test.js
+++ b/test.js
@@ -1,21 +1,23 @@
 var test = require('tape');
 var DatAPI = require('./')
 
-var dat = DatAPI({ 
-  remote: 'http://127.0.0.1:6461',
+var dat = DatAPI({
+  url: 'http://127.0.0.1:6461',
   user: 'foo',
   pass: 'bar'
 })
 
 test('get dat repo info', function (t) {
   dat.info(function (err, res, body) {
+    t.ifError(err)
     t.ok(body, 'dat repo info response')
     t.end()
   })
 })
 
 test('post rows', function (t) {
-  dat.postRows({ wee: 'foo' }, function (err, res, body) {
+  dat.put({ wee: 'foo' }, function (err, res, body) {
+    t.ifError(err)
     t.ok(body, 'post response body')
     t.equals(body.wee, 'foo')
     t.end()
@@ -23,15 +25,17 @@ test('post rows', function (t) {
 })
 
 test('get rows', function (t) {
-  dat.rows(function (err, res, rows) {
+  dat.get(function (err, res, rows) {
+    t.ifError(err)
     t.ok(rows, 'rows object exists')
     t.end()
   })
 })
 
 test('get row', function (t) {
-  dat.postRows({ wee: 'foo' }, function (err, res, body) {
-    dat.row(body.key, function (err, res, row) {
+  dat.put({ wee: 'foo' }, function (err, res, body) {
+    dat.get(body.key, function (err, res, row) {
+      t.ifError(err)
       t.ok(row, 'row object exists')
       t.equals(row.wee, 'foo')
       t.end()
@@ -39,12 +43,29 @@ test('get row', function (t) {
   })
 })
 
+
+test('post bulk json data', function (t) {
+  var data = [
+    { wee: 'foo'},
+    { beep: 'boop'}
+  ]
+
+  dat.bulk(data, { type: 'json' }, function (err, res, body) {
+    t.ifError(err)
+    t.ok(body, 'bulk response ok')
+    t.end()
+  })
+})
+
+
 test('post bulk csv data', function (t) {
   var csv = 'wee,woo\n1,a\n2,b\n3,c'
 
   dat.bulk(csv.toString(), { type: 'csv' }, function (err, res, body) {
-    console.log(body)
-    t.ok(body, 'bulk response body')
-    t.end()
+    t.ifError(err)
+    res.on('end', function () {
+      t.ok(body, 'bulk response')
+      t.end()
+    })
   })
 })


### PR DESCRIPTION
This way it'll be easy to browserify the js api when connecting to a remote dat, just by changing the require statement (mostly. it still needs some work)

also adds travis and badges
